### PR TITLE
raise error if organization can not be validated

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -78,11 +78,12 @@ func (c *Config) Clients() (interface{}, error) {
 		owner.name = user.GetLogin()
 	} else {
 		remoteOrg, _, err := owner.v3client.Organizations.Get(ctx, owner.name)
-		if err == nil {
-			if remoteOrg != nil {
-				owner.id = remoteOrg.GetID()
-				owner.IsOrganization = true
-			}
+		if err != nil {
+			return nil, err
+		}
+		if remoteOrg != nil {
+			owner.id = remoteOrg.GetID()
+			owner.IsOrganization = true
 		}
 	}
 	return &owner, nil


### PR DESCRIPTION
Currently the requests silently fails and leads to a misleading error message `This resource can only be used in the context of an organization, "ORGANIZATION" is a user.`. 
To make it more visible when e.g. the request failed due to throttles it will return an error now. 

This was introduced here https://github.com/terraform-providers/terraform-provider-github/pull/464